### PR TITLE
Bug fixes, load/run/import functionality added

### DIFF
--- a/ragxplorer/query_expansion.py
+++ b/ragxplorer/query_expansion.py
@@ -13,8 +13,6 @@ from openai import OpenAI
 
 from .constants import MULTIPLE_QNS_SYS_MSG, HYDE_SYS_MSG
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-
 def generate_sub_qn(query: str) -> List[str]:
     """
     Generates sub-questions for a given query using the GPT-4 model.
@@ -68,6 +66,8 @@ def _chat_completion(sys_msg: str, prompt: str, response_format: str) -> Union[s
     Raises:
         OpenAIError: If an error occurs in the OpenAI API call.
     """
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    
     response = client.chat.completions.create(
         model="gpt-4-1106-preview",
         messages=[{'role': 'system', 'content': sys_msg}, 

--- a/ragxplorer/ragxplorer.py
+++ b/ragxplorer/ragxplorer.py
@@ -122,24 +122,12 @@ class RAGxplorer(BaseModel):
         if verbose:
             print("Completed reducing dimensionality of embeddings ✓")
 
-    def visualize_query(self, query: str, retrieval_method: str="naive", top_k:int=5, query_shape_size:int=5) -> go.Figure:
-        """
-        Visualize the query results in a 2D projection using Plotly.
-
-        Args:
-            query (str): The query string to visualize.
-            retrieval_method (str): The method used for document retrieval. Defaults to 'naive'.
-            top_k (int): The number of top documents to retrieve.
-            query_shape_size (int): The size of the shape to represent the query in the plot.
-
-        Returns:
-            go.Figure: A Plotly figure object representing the visualization.
-
-        Raises:
-            RuntimeError: If the document has not been loaded before visualization.
-        """
-        if self._vectordb is None or self._VizData.base_df is None:
-            raise RuntimeError("Please load the pdf first.")
+    def visualize_query(self, query: str, retrieval_method: str="naive", top_k:int=5, query_shape_size:int=5, import_projection_data:pd.DataFrame = None) -> go.Figure:
+        if import_projection_data is not None:
+            self._VizData.base_df = import_projection_data
+        else:
+            if self._vectordb is None or self._VizData.base_df is None:
+                raise RuntimeError("Please load the pdf first.")
         
         if retrieval_method not in ["naive", "HyDE", "multi_qns"]:
             raise ValueError("Invalid retrieval method. Please use naive, HyDE, or multi_qns.")
@@ -206,7 +194,7 @@ class RAGxplorer(BaseModel):
         """
         return self._vectordb
     
-    def load_chroma(self, chroma_collection: Collection, recompute_projections: bool = False, umap_params: dict = None,):
+    def load_chroma(self, chroma_collection: Collection, initialize_projector: bool = False, recompute_projections: bool = False, umap_params: dict = None,):
         """
         Load ChromaDB collection.
         """
@@ -214,6 +202,8 @@ class RAGxplorer(BaseModel):
         self._documents.embeddings = get_doc_embeddings(self._vectordb)
         self._documents.text = get_docs(self._vectordb)
         self._documents.ids = self._vectordb.get()['ids']
+        if initialize_projector:
+            self._projector = set_up_umap(embeddings=self._documents.embeddings, umap_params=umap_params)
         if recompute_projections:
             self._projector = set_up_umap(embeddings=self._documents.embeddings, umap_params=umap_params)
             self._documents.projections = get_projections(embedding=self._documents.embeddings,
@@ -239,3 +229,12 @@ class RAGxplorer(BaseModel):
             self._VizData.base_df = prepare_projections_df(document_ids=self._documents.ids,
                                                            document_projections=self._documents.projections,
                                                            document_text=self._documents.text)
+    def run_projector(self):
+        """
+        Run UMAP projector.
+        """
+        self._documents.projections = get_projections(embedding=self._documents.embeddings,
+                                                      umap_transform=self._projector)
+        self._VizData.base_df = prepare_projections_df(document_ids=self._documents.ids,
+                                                               document_projections=self._documents.projections,
+                                                               document_text=self._documents.text)

--- a/ragxplorer/ragxplorer.py
+++ b/ragxplorer/ragxplorer.py
@@ -78,13 +78,11 @@ class RAGxplorer(BaseModel):
     def _set_embedding_model(self):
         """ Sets the embedding model """
         if self.embedding_model == 'all-MiniLM-L6-v2':
-            print(f'Embedding model chosen: {str(self.embedding_model)}')
             self._chosen_embedding_model = SentenceTransformerEmbeddingFunction()
 
         elif self.embedding_model in OPENAI_EMBEDDING_MODELS:
             if "OPENAI_API_KEY" not in os.environ:
                 raise OSError("OPENAI_API_KEY is not set")
-            print(f'Embedding model chosen: {str(self.embedding_model)}')
             self._chosen_embedding_model = OpenAIEmbeddingFunction(api_key = os.getenv("OPENAI_API_KEY"), 
                                                                    model_name = self.embedding_model)
         else:
@@ -137,6 +135,8 @@ class RAGxplorer(BaseModel):
         self._query.original_query = query
 
         if (self.embedding_model == "all-MiniLM-L6-v2") or (self.embedding_model in OPENAI_EMBEDDING_MODELS):
+            # Brackets around the query required as per latest update to openai client (https://platform.openai.com/docs/guides/embeddings/use-cases). 
+            # It doesn't look like chromadb updated to reflect this.
             self._query.original_query_projection = get_projections(embedding=self._chosen_embedding_model([self._query.original_query]),
                                                                     umap_transform=self._projector)
         else:


### PR DESCRIPTION
Bugs fixed:

1. OpenAI client was calculating embeddings for each character, not the entire query in visualize_query. I fixed this and commented.
2. Moved client initialization in query_expansion.py to the function where it was used. Otherwise RAGxplorer cannot import if the environment variable is not initialized.

Functionality added:

1. Added initialize_projector to load_chroma, so that there is an option to just initialize the projector, rather than run the full projections. I have a use case where I initialize the umap parameters, create a random sample from a large database, then run projections. The random sampling is a unique thing I didn't think fit into RAGxplorer, but is helpful for large datasets you want to visualize.
2. Added run_projector, which complements export projector and the options I added for initialize_projector.
3. Added import_projection_data to visualize_query, which reads in a dataframe containing saved projection data. I did not integrate this functionality into RAGxplorer, but if this is a common use case, we should.